### PR TITLE
Target modern runtimes, add credo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 
 elixir:
-  - 1.6
   - 1.7
+  - 1.8
 
 cache:
   directories:
@@ -11,4 +11,5 @@ cache:
 
 script:
   - mix test
+  - mix credo --strict
   - mix dialyzer

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: elixir
 
 otp_release:
   - 20.3
-  - 21.1
+  - 21.2
 
 elixir:
   - 1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: elixir
 
+otp_release:
+  - 20.3
+  - 21.1
+
 elixir:
   - 1.7
   - 1.8

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule HPack.Mixfile do
     [
       app: :hpack,
       version: "1.1.0",
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       package: package(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -23,8 +23,9 @@ defmodule HPack.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, "~> 0.18.0", only: :dev, runtime: false},
-      {:dialyxir, "~> 0.5.1", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.19.0", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,10 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "1.0.0", "aaa40fdd0543a0cf8080e8c5949d8c25f0a24e4fc8c1d83d06c388f5e5e0ea42", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},

--- a/test/rfc-spec/decode_test.exs
+++ b/test/rfc-spec/decode_test.exs
@@ -3,7 +3,7 @@ defmodule HPack.RFCSpec.DecodeTest do
   import RFCBinaries
 
   setup do
-    {:ok, table} = HPack.Table.start_link(10000)
+    {:ok, table} = HPack.Table.start_link(10_000)
     {:ok, table: table}
   end
 

--- a/test/rfc-spec/encode_test.exs
+++ b/test/rfc-spec/encode_test.exs
@@ -3,7 +3,7 @@ defmodule HPack.RFCSpec.EncodeTest do
   import RFCBinaries
 
   setup do
-    {:ok, table} = HPack.Table.start_link(10000)
+    {:ok, table} = HPack.Table.start_link(10_000)
     {:ok, table: table}
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,15 +4,15 @@ defmodule RFCBinaries do
   def sigil_b(string, []) do
     string
     |> String.split("\n")
-    |> Enum.map(fn part -> String.split(part, "|") |> List.first() end)
-    |> Enum.map(fn part -> String.split(part, " ") end)
+    |> Enum.map(fn part -> part |> String.split("|") |> List.first() end)
+    |> Enum.map(fn part -> part |> String.split(" ") end)
     |> List.flatten()
     |> Enum.filter(&(byte_size(&1) > 0))
     |> Enum.map(fn part -> String.to_integer(part, 16) end)
     |> Enum.map(fn i ->
       case i do
         x when x in 0..255 -> <<x::size(8)>>
-        x when x in 256..65535 -> <<x::size(16)>>
+        x when x in 256..65_535 -> <<x::size(16)>>
       end
     end)
     |> Enum.reduce(fn b, acc -> acc <> b end)


### PR DESCRIPTION
This adds credo to the build process and runs the tests on the last two major OTP releases and minor Elixir releases.