### PR TITLE
Return errors instead of throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ HPack.decode(<< 0x82 >>, ctx)
 ```elixir
 {:ok, ctx} = HPack.Table.start_link(1000)
 HPack.encode([{":method", "GET"}], ctx)
-# => << 0b10000010 >>
+# => {:ok. << 0b10000010 >>}
 ```
 
 ## Acknowledgements

--- a/lib/hpack.ex
+++ b/lib/hpack.ex
@@ -19,31 +19,34 @@ defmodule HPack do
 
       iex> {:ok, ctx} = HPack.Table.start_link(1000)
       iex> HPack.encode([{":method", "GET"}], ctx)
-      << 0b10000010 >>
+      {:ok, << 0b10000010 >>}
 
   """
-  @spec encode([header], Table.t()) :: header_block_fragment
-  def encode(headers, table) when is_list(headers), do: encode(headers, <<>>, table)
+  @spec encode([header], Table.t()) :: {:ok, header_block_fragment} | {:error, :encode_error}
+  def encode(headers, table), do: encode(headers, <<>>, table)
 
-  defp encode([], hbf, _), do: hbf
+  defp encode([], hbf, _), do: {:ok, hbf}
 
   defp encode([{key, value} | headers], hbf, table) do
     partial =
       case Table.find(key, value, table) do
         {:fullindex, index} -> encode_indexed(index)
         {:keyindex, index} -> encode_literal_indexed(index, value, table)
-        {:none} -> encode_literal_not_indexed(key, value, table)
+        {:error, :not_found} -> encode_literal_not_indexed(key, value, table)
       end
 
     encode(headers, hbf <> partial, table)
   end
 
+  defp encode(_headers, _hbf, _table), do: {:error, :encode_error}
+
   defp encode_indexed(index), do: <<1::1, encode_int7(index)::bitstring>>
 
   defp encode_literal_indexed(index, value, table) do
-    {name, _} = Table.lookup(index, table)
-    Table.add({name, value}, table)
-    <<0::1, 1::1, encode_int6(index)::bitstring, encode_string(value)::binary>>
+    with {:ok, {name, _}} <- Table.lookup(index, table) do
+      Table.add({name, value}, table)
+      <<0::1, 1::1, encode_int6(index)::bitstring, encode_string(value)::binary>>
+    end
   end
 
   defp encode_literal_not_indexed(name, value, table) do
@@ -77,24 +80,27 @@ defmodule HPack do
 
       iex> {:ok, ctx} = HPack.Table.start_link(1000)
       iex> HPack.decode(<< 0x82 >>, ctx)
-      [{":method", "GET"}]
+      {:ok, [{":method", "GET"}]}
 
   """
-  @spec decode(header_block_fragment, Table.t()) :: [header]
-  def decode(hbf, table) do
-    parse(hbf, [], table)
+  @spec decode(header_block_fragment, Table.t(), integer | nil) :: {:ok, [header]} | {:error, :decode_error}
+  def decode(hbf, table, max_size \\ nil)
+
+  def decode(hbf, table, max_size) do
+    parse(hbf, [], table, max_size)
   end
 
-  defp parse(<<>>, headers, _), do: Enum.reverse(headers)
+  defp parse(<<>>, headers, _table, _max_size), do: {:ok, Enum.reverse(headers)}
 
   #   0   1   2   3   4   5   6   7
   # +---+---+---+---+---+---+---+---+
   # | 1 |        Index (7+)         |
   # +---+---------------------------+
   #  Figure 5: Indexed Header Field
-  defp parse(<<1::1, rest::bitstring>>, headers, table) do
+  defp parse(<<1::1, rest::bitstring>>, headers, table, max_size) do
     {index, rest} = parse_int7(rest)
-    parse(rest, [Table.lookup(index, table) | headers], table)
+    with {:ok, {header, value}} <- Table.lookup(index, table),
+      do: parse(rest, [{header, value} | headers], table, max_size)
   end
 
   #   0   1   2   3   4   5   6   7
@@ -110,11 +116,11 @@ defmodule HPack do
   # | Value String (Length octets)  |
   # +-------------------------------+
   # Figure 7: Literal Header Field with Incremental Indexing — New Name
-  defp parse(<<0::1, 1::1, 0::6, rest::binary>>, headers, table) do
+  defp parse(<<0::1, 1::1, 0::6, rest::binary>>, headers, table, max_size) do
     {name, rest} = parse_string(rest)
     {value, more_headers} = parse_string(rest)
     Table.add({name, value}, table)
-    parse(more_headers, [{name, value} | headers], table)
+    parse(more_headers, [{name, value} | headers], table, max_size)
   end
 
   #  0   1   2   3   4   5   6   7
@@ -126,12 +132,13 @@ defmodule HPack do
   # | Value String (Length octets)  |
   # +-------------------------------+
   # Figure 6: Literal Header Field with Incremental Indexing — Indexed Name
-  defp parse(<<0::1, 1::1, rest::bitstring>>, headers, table) do
+  defp parse(<<0::1, 1::1, rest::bitstring>>, headers, table, max_size) do
     {index, rest} = parse_int6(rest)
     {value, more_headers} = parse_string(rest)
-    {header, _} = Table.lookup(index, table)
-    Table.add({header, value}, table)
-    parse(more_headers, [{header, value} | headers], table)
+    with {:ok, {header, _}} <- Table.lookup(index, table) do
+      Table.add({header, value}, table)
+      parse(more_headers, [{header, value} | headers], table, max_size)
+    end
   end
 
   #   0   1   2   3   4   5   6   7
@@ -147,10 +154,10 @@ defmodule HPack do
   # | Value String (Length octets)  |
   # +-------------------------------+
   # Figure 9: Literal Header Field without Indexing — New Name
-  defp parse(<<0::4, 0::4, rest::binary>>, headers, table) do
+  defp parse(<<0::4, 0::4, rest::binary>>, headers, table, max_size) do
     {name, rest} = parse_string(rest)
     {value, more_headers} = parse_string(rest)
-    parse(more_headers, [{name, value} | headers], table)
+    parse(more_headers, [{name, value} | headers], table, max_size)
   end
 
   #   0   1   2   3   4   5   6   7
@@ -162,11 +169,11 @@ defmodule HPack do
   # | Value String (Length octets)  |
   # +-------------------------------+
   # Figure 8: Literal Header Field without Indexing — Indexed Name
-  defp parse(<<0::4, rest::bitstring>>, headers, table) do
+  defp parse(<<0::4, rest::bitstring>>, headers, table, max_size) do
     {index, rest} = parse_int4(rest)
     {value, more_headers} = parse_string(rest)
-    {header, _} = Table.lookup(index, table)
-    parse(more_headers, [{header, value} | headers], table)
+    with {:ok, {header, _}} <- Table.lookup(index, table),
+      do: parse(more_headers, [{header, value} | headers], table, max_size)
   end
 
   #   0   1   2   3   4   5   6   7
@@ -182,10 +189,10 @@ defmodule HPack do
   # | Value String (Length octets)  |
   # +-------------------------------+
   # Figure 11: Literal Header Field Never Indexed — New Name
-  defp parse(<<0::3, 1::1, 0::4, rest::binary>>, headers, table) do
+  defp parse(<<0::3, 1::1, 0::4, rest::binary>>, headers, table, max_size) do
     {name, rest} = parse_string(rest)
     {value, more_headers} = parse_string(rest)
-    parse(more_headers, [{name, value} | headers], table)
+    parse(more_headers, [{name, value} | headers], table, max_size)
   end
 
   #   0   1   2   3   4   5   6   7
@@ -197,11 +204,11 @@ defmodule HPack do
   # | Value String (Length octets)  |
   # +-------------------------------+
   # Figure 10: Literal Header Field Never Indexed — Indexed Name
-  defp parse(<<0::3, 1::1, rest::bitstring>>, headers, table) do
+  defp parse(<<0::3, 1::1, rest::bitstring>>, headers, table, max_size) do
     {index, rest} = parse_int4(rest)
     {value, more_headers} = parse_string(rest)
-    {header, _} = Table.lookup(index, table)
-    parse(more_headers, [{header, value} | headers], table)
+    with {:ok, {header, _}} <- Table.lookup(index, table),
+      do: parse(more_headers, [{header, value} | headers], table, max_size)
   end
 
   #   0   1   2   3   4   5   6   7
@@ -209,10 +216,10 @@ defmodule HPack do
   # | 0 | 0 | 1 |   Max size (5+)   |
   # +---+---------------------------+
   # Figure 12: Maximum Dynamic Table Size Change
-  defp parse(<<0::2, 1::1, rest::bitstring>>, headers, table) do
+  defp parse(<<0::2, 1::1, rest::bitstring>>, headers, table, max_size) do
     {size, rest} = parse_int5(rest)
-    Table.resize(size, table)
-    parse(rest, headers, table)
+    with :ok <- Table.resize(size, table, max_size),
+      do: parse(rest, headers, table, max_size)
   end
 
   defp parse_string(<<0::1, rest::bitstring>>) do
@@ -241,6 +248,5 @@ defmodule HPack do
 
   defp parse_big_int(<<0::1, value::7, rest::binary>>, int, m), do: {int + (value <<< m), rest}
 
-  defp parse_big_int(<<1::1, value::7, rest::binary>>, int, m),
-    do: parse_big_int(rest, int + (value <<< m), m + 7)
+  defp parse_big_int(<<1::1, value::7, rest::binary>>, int, m), do: parse_big_int(rest, int + (value <<< m), m + 7)
 end

--- a/lib/hpack.ex
+++ b/lib/hpack.ex
@@ -95,7 +95,7 @@ defmodule HPack do
   def decode(<<0::2, 1::1, rest::bitstring>>, table, max_size) do
     with {:ok, {size, rest}} <- parse_int5(rest),
          :ok <- Table.resize(size, table, max_size),
-      do: parse(rest, [], table)
+      do: decode(rest, table, max_size)
   end
 
   def decode(hbf, table, _max_size) do

--- a/test/hpack/huffman_test.exs
+++ b/test/hpack/huffman_test.exs
@@ -6,7 +6,7 @@ defmodule HuffmanTest do
   alias HPack.Huffman
 
   test "decode a simple character" do
-    assert "%" == Huffman.decode(<<0x15::6>>)
+    assert {:ok, "%"} == Huffman.decode(<<0x15::6>>)
   end
 
   test "decode a sentence" do
@@ -15,7 +15,7 @@ defmodule HuffmanTest do
       0x78::7, 0x7::5, 0x2c::6, 0x28::6, 0x24::6, 0x3f8::10
     >>
 
-    assert "hello world!" == Huffman.decode(hello_world)
+    assert {:ok, "hello world!"} == Huffman.decode(hello_world)
   end
 
   test "decode with padding" do
@@ -23,21 +23,21 @@ defmodule HuffmanTest do
       0x27::6, 0x5::5, 0x28::6, 0x28::6, 0x7::5, 0b1111::4
     >>
 
-    assert "hello" == Huffman.decode(hello)
+    assert {:ok, "hello"} == Huffman.decode(hello)
   end
 
   test "encode a simple character" do
-    assert Huffman.encode("%") == <<0b01010111>>
+    assert Huffman.encode("%") == {:ok, <<0b01010111>>}
   end
 
   test "encode two simple characters" do
-    assert Huffman.encode("%%") == <<0b0101010101011111::16>>
+    assert Huffman.encode("%%") == {:ok, <<0b0101010101011111::16>>}
   end
 
   test "encode a sentence" do
-    assert Huffman.encode("hello world!") == <<
+    assert Huffman.encode("hello world!") == {:ok, <<
       0x27::6, 0x5::5, 0x28::6, 0x28::6, 0x7::5, 0x14::6,
       0x78::7, 0x7::5, 0x2c::6, 0x28::6, 0x24::6, 0x3f8::10, 0b111111::6
-    >>
+    >>}
   end
 end

--- a/test/hpack/table_test.exs
+++ b/test/hpack/table_test.exs
@@ -10,20 +10,20 @@ defmodule HPack.TableTest do
   end
 
   test "lookp up from static table", %{table: table} do
-    assert {":method", "GET"} = Table.lookup(2, table)
+    assert {:ok, {":method", "GET"}} = Table.lookup(2, table)
   end
 
   test "adding to dynamic table", %{table: table} do
     header = {"some-header", "some-value"}
     Table.add(header, table)
-    assert header == Table.lookup(62, table)
+    assert {:ok, header} == Table.lookup(62, table)
   end
 
   test "adds to dynamic table at the beginning", %{table: table} do
     second_header = {"some-header-2", "some-value-2"}
     Table.add({"some-header", "some-value"}, table)
     Table.add(second_header, table)
-    assert second_header == Table.lookup(62, table)
+    assert {:ok, second_header} == Table.lookup(62, table)
   end
 
   test "evict entries on table size change", %{table: table} do
@@ -31,7 +31,7 @@ defmodule HPack.TableTest do
     Table.add(header, table)
     # evict all entries in dynamic table
     Table.resize(0, table)
-    assert :none == Table.lookup(62, table)
+    assert {:error, :not_found} == Table.lookup(62, table)
   end
 
   test "evict oldest entries when size > table size", %{table: table} do
@@ -42,8 +42,8 @@ defmodule HPack.TableTest do
     Table.add({"some-header-2", "some-value-2"}, table)
     Table.add(third_header, table)
 
-    assert third_header == Table.lookup(62, table)
-    assert :none == Table.lookup(63, table)
+    assert {:ok, third_header} == Table.lookup(62, table)
+    assert {:error, :not_found} == Table.lookup(63, table)
   end
 
   test "find a key with corresponding value from static table", %{table: table} do
@@ -55,7 +55,7 @@ defmodule HPack.TableTest do
   end
 
   test "return :none when key not found in table", %{table: table} do
-    assert Table.find("x-something", "some-value", table) == {:none}
+    assert Table.find("x-something", "some-value", table) == {:error, :not_found}
   end
 
   test "find a key with corresponding value from dynamic table", %{table: table} do

--- a/test/hpack_test.exs
+++ b/test/hpack_test.exs
@@ -11,7 +11,7 @@ defmodule HPackTest do
   end
 
   test "decode from static table", %{table: table} do
-    assert hd(HPack.decode(<<0x82>>, table)) == {":method", "GET"}
+    assert HPack.decode(<<0x82>>, table) == {:ok, [{":method", "GET"}]}
   end
 
   test "decode big number (Index5+)", %{table: table} do
@@ -21,7 +21,7 @@ defmodule HPackTest do
 
     # Maximum Dynamic Table Size Change header to 1337
     hbf = <<0b00111111, 0b10011010, 0b00001010>>
-    headers = HPack.decode(hbf, table)
+    {:ok, headers} = HPack.decode(hbf, table)
 
     assert Table.size(table) <= 1337
     assert headers == []
@@ -31,11 +31,11 @@ defmodule HPackTest do
     super_long_value =
       "very long long value Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam,"
 
-    hbf = HPack.encode([{"short-key", super_long_value}], table)
+    {:ok, hbf} = HPack.encode([{"short-key", super_long_value}], table)
 
     {:ok, decode_table} = Table.start_link(1000)
 
-    assert HPack.decode(hbf, decode_table) == [{"short-key", super_long_value}]
+    assert HPack.decode(hbf, decode_table) == {:ok, [{"short-key", super_long_value}]}
   end
 
   @doc """
@@ -80,6 +80,6 @@ defmodule HPackTest do
         170, 98, 163, 132, 143, 210, 74, 143>>
 
     {:ok, pid} = HPack.Table.start_link(4_096)
-    assert [_head | _tail] = HPack.decode(data, pid)
+    assert {:ok, [_head | _tail]} = HPack.decode(data, pid)
   end
 end

--- a/test/rfc-spec/decode_test.exs
+++ b/test/rfc-spec/decode_test.exs
@@ -15,7 +15,7 @@ defmodule HPack.RFCSpec.DecodeTest do
       746f 6d2d 6865 6164 6572                | tom-header
     )
 
-    [decoded_header | _] = HPack.decode(hbf, table)
+    assert {:ok, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {"custom-key", "custom-header"}
     assert HPack.Table.size(table) == 55
   end
@@ -25,7 +25,7 @@ defmodule HPack.RFCSpec.DecodeTest do
   test "Literal Header Field without Indexing", %{table: table} do
     hbf = ~b(040c 2f73 616d 706c 652f 7061 7468      | ../sample/path)
 
-    [decoded_header | _] = HPack.decode(hbf, table)
+    assert {:ok, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {":path", "/sample/path"}
     assert HPack.Table.size(table) == 0
   end
@@ -38,7 +38,7 @@ defmodule HPack.RFCSpec.DecodeTest do
       74                                      | t
     )
 
-    [decoded_header | _] = HPack.decode(hbf, table)
+    assert {:ok, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {"password", "secret"}
     assert HPack.Table.size(table) == 0
   end
@@ -48,7 +48,7 @@ defmodule HPack.RFCSpec.DecodeTest do
   test "Indexed Header Field", %{table: table} do
     hbf = ~b(82 | .)
 
-    [decoded_header | _] = HPack.decode(hbf, table)
+    assert {:ok, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {":method", "GET"}
     assert HPack.Table.size(table) == 0
   end
@@ -62,12 +62,12 @@ defmodule HPack.RFCSpec.DecodeTest do
       2e63 6f6d                               | .com
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":method", "GET"},
              {":scheme", "http"},
              {":path", "/"},
              {":authority", "www.example.com"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 57
 
@@ -76,13 +76,13 @@ defmodule HPack.RFCSpec.DecodeTest do
       8286 84be 5808 6e6f 2d63 6163 6865      | ....X.no-cache
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":method", "GET"},
              {":scheme", "http"},
              {":path", "/"},
              {":authority", "www.example.com"},
              {"cache-control", "no-cache"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 110
 
@@ -92,13 +92,13 @@ defmodule HPack.RFCSpec.DecodeTest do
       0c63 7573 746f 6d2d 7661 6c75 65        | .custom-value
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":method", "GET"},
              {":scheme", "https"},
              {":path", "/index.html"},
              {":authority", "www.example.com"},
              {"custom-key", "custom-value"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 164
   end
@@ -112,12 +112,12 @@ defmodule HPack.RFCSpec.DecodeTest do
       ff                                      | .
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":method", "GET"},
              {":scheme", "http"},
              {":path", "/"},
              {":authority", "www.example.com"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 57
 
@@ -126,13 +126,13 @@ defmodule HPack.RFCSpec.DecodeTest do
       8286 84be 5886 a8eb 1064 9cbf           | ....X....d..
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":method", "GET"},
              {":scheme", "http"},
              {":path", "/"},
              {":authority", "www.example.com"},
              {"cache-control", "no-cache"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 110
 
@@ -142,13 +142,13 @@ defmodule HPack.RFCSpec.DecodeTest do
       a849 e95b b8e8 b4bf                     | .I.[....
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":method", "GET"},
              {":scheme", "https"},
              {":path", "/index.html"},
              {":authority", "www.example.com"},
              {"custom-key", "custom-value"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 164
   end
@@ -167,12 +167,12 @@ defmodule HPack.RFCSpec.DecodeTest do
       6c65 2e63 6f6d                          | le.com
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":status", "302"},
              {"cache-control", "private"},
              {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
              {"location", "https://www.example.com"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 222
 
@@ -181,12 +181,12 @@ defmodule HPack.RFCSpec.DecodeTest do
       4803 3330 37c1 c0bf                     | H.307...
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":status", "307"},
              {"cache-control", "private"},
              {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
              {"location", "https://www.example.com"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 222
 
@@ -201,14 +201,14 @@ defmodule HPack.RFCSpec.DecodeTest do
       3d31                                    | =1
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":status", "200"},
              {"cache-control", "private"},
              {"date", "Mon, 21 Oct 2013 20:13:22 GMT"},
              {"location", "https://www.example.com"},
              {"content-encoding", "gzip"},
              {"set-cookie", "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 215
   end
@@ -226,12 +226,12 @@ defmodule HPack.RFCSpec.DecodeTest do
       e9ae 82ae 43d3                          | ....C.
     /
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":status", "302"},
              {"cache-control", "private"},
              {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
              {"location", "https://www.example.com"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 222
 
@@ -240,12 +240,12 @@ defmodule HPack.RFCSpec.DecodeTest do
       4883 640e ffc1 c0bf                     | H.d.....
     )
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":status", "307"},
              {"cache-control", "private"},
              {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
              {"location", "https://www.example.com"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 222
 
@@ -258,14 +258,14 @@ defmodule HPack.RFCSpec.DecodeTest do
       9587 3160 65c0 03ed 4ee5 b106 3d50 07   | ..1`e...N...=P.
     /
 
-    assert HPack.decode(hbf, table) == [
+    assert HPack.decode(hbf, table) == {:ok, [
              {":status", "200"},
              {"cache-control", "private"},
              {"date", "Mon, 21 Oct 2013 20:13:22 GMT"},
              {"location", "https://www.example.com"},
              {"content-encoding", "gzip"},
              {"set-cookie", "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1"}
-           ]
+           ]}
 
     assert HPack.Table.size(table) == 215
   end

--- a/test/rfc-spec/encode_test.exs
+++ b/test/rfc-spec/encode_test.exs
@@ -11,7 +11,7 @@ defmodule HPack.RFCSpec.EncodeTest do
   @tag :rfc
   test "Indexed Header Field", %{table: table} do
     headers = [{":method", "GET"}]
-    assert HPack.encode(headers, table) == ~b(82 | .)
+    assert HPack.encode(headers, table) == {:ok, ~b(82 | .)}
   end
 
   # C.4 Request Examples with Huffman Coding
@@ -25,10 +25,10 @@ defmodule HPack.RFCSpec.EncodeTest do
       {":authority", "www.example.com"}
     ]
 
-    assert HPack.encode(headers, table) == ~b(
+    assert HPack.encode(headers, table) == {:ok, ~b(
       8286 8441 8cf1 e3c2 e5f2 3a6b a0ab 90f4 | ...A......:k....
       ff                                      | .
-    )
+    )}
 
     # C.4.2 Second Request
     headers = [
@@ -39,9 +39,9 @@ defmodule HPack.RFCSpec.EncodeTest do
       {"cache-control", "no-cache"}
     ]
 
-    assert HPack.encode(headers, table) == ~b(
+    assert HPack.encode(headers, table) == {:ok, ~b(
       8286 84be 5886 a8eb 1064 9cbf           | ....X....d..
-    )
+    )}
 
     # C.4.3 Third Request
     headers = [
@@ -52,10 +52,10 @@ defmodule HPack.RFCSpec.EncodeTest do
       {"custom-key", "custom-value"}
     ]
 
-    assert HPack.encode(headers, table) == ~b(
+    assert HPack.encode(headers, table) == {:ok, ~b(
       8287 85bf 4088 25a8 49e9 5ba9 7d7f 8925 | ....@.%.I.[.}..%
       a849 e95b b8e8 b4bf                     | .I.[....
-    )
+    )}
   end
 
   # C.6 Response Examples with Huffman Coding
@@ -71,12 +71,12 @@ defmodule HPack.RFCSpec.EncodeTest do
       {"location", "https://www.example.com"}
     ]
 
-    assert HPack.encode(headers, table) == ~b/
+    assert HPack.encode(headers, table) == {:ok, ~b/
       4882 6402 5885 aec3 771a 4b61 96d0 7abe | H.d.X...w.Ka..z.
       9410 54d4 44a8 2005 9504 0b81 66e0 82a6 | ..T.D. .....f...
       2d1b ff6e 919d 29ad 1718 63c7 8f0b 97c8 | -..n..)...c.....
       e9ae 82ae 43d3                          | ....C.
-    /
+    /}
 
     # C.6.2 Second Response
     headers = [
@@ -86,9 +86,9 @@ defmodule HPack.RFCSpec.EncodeTest do
       {"location", "https://www.example.com"}
     ]
 
-    assert HPack.encode(headers, table) == ~b(
+    assert HPack.encode(headers, table) == {:ok, ~b(
       4883 640e ffc1 c0bf                     | H.d.....
-    )
+    )}
 
     # C.6.3 Third Response
     headers = [
@@ -100,12 +100,12 @@ defmodule HPack.RFCSpec.EncodeTest do
       {"set-cookie", "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1"}
     ]
 
-    assert HPack.encode(headers, table) == ~b/
+    assert HPack.encode(headers, table) == {:ok, ~b/
       88c1 6196 d07a be94 1054 d444 a820 0595 | ..a..z...T.D. ..
       040b 8166 e084 a62d 1bff c05a 839b d9ab | ...f...-...Z....
       77ad 94e7 821d d7f2 e6c7 b335 dfdf cd5b | w..........5...[
       3960 d5af 2708 7f36 72c1 ab27 0fb5 291f | 9`..'..6r..'..).
       9587 3160 65c0 03ed 4ee5 b106 3d50 07   | ..1`e...N...=P.
-    /
+    /}
   end
 end


### PR DESCRIPTION
So, this is a first stab at changing the interface of the `HPack` and `HPack.Table` public API to return `{:ok, result} | {:error, reason}` tuples instead of throwing.

As a bonus, it also adds an (optional) `max_size` argument to `HPack.decode` and `HPack.Table.resize`. This is needed because dynamic table size updates need to be bounded and the limit is maintained by the user of the decoder (in my case the HTTP/2 protocol). When the dynamic table size update exceeds `max_size` an error is returned.

I think there are probably cases where exceptions are generated by incomplete pattern matches on function heads, so it probably needs more work. Tests pass though, and a few initial tests with my HTTP/2 implementations look good.

This addresses #10 