### PR TITLE
Processless and API refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,17 @@ The HPack library has a simple interface. You will need two functions:
 ### Decoding
 
 ```elixir
-{:ok, table, headers} =
-  1_000
-  |> HPack.Table.new()
-  |> HPack.decode(<< 0x82 >>)
-# => {:ok, ..., [{":method", "GET"}]}
+ctx = HPack.Table.new(1000)
+HPack.decode(<< 0x82 >>, ctx)
+# => [{":method", "GET"}]
 ```
 
 ### Encoding
 
 ```elixir
-{:ok, table, hbf} =
-  HPack.Table.new(1_000)
-  |> HPack.encode([{":method", "GET"}])
-# => {:ok, ..., << 0b10000010 >>}
+ctx = HPack.Table.new(1000)
+HPack.encode([{":method", "GET"}], ctx)
+# => {:ok. << 0b10000010 >>}
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -13,31 +13,41 @@ Implementation of the [HPack](https://http2.github.io/http2-spec/compression.htm
   ```
 
 ## Usage
+
 The HPack library has a simple interface. You will need two functions:
 
 ### Decoding
+
 ```elixir
-ctx = HPack.Table.new(1_000)
-{:ok, table, headers} = HPack.decode(ctx, (<< 0x82 >>)
+{:ok, table, headers} =
+  1_000
+  |> HPack.Table.new()
+  |> HPack.decode(<< 0x82 >>)
 # => {:ok, ..., [{":method", "GET"}]}
 ```
 
 ### Encoding
+
 ```elixir
-ctx = HPack.Table.new(1_000)
-{:ok, table, hbf} = HPack.encode(ctx, [{":method", "GET"}])
+{:ok, table, hbf} =
+  1_000
+  |> HPack.Table.new()
+  |> HPack.encode([{":method", "GET"}])
 # => {:ok, ..., << 0b10000010 >>}
 ```
 
 ## Acknowledgements
+
 The [cowboy hpack implementation](https://github.com/ninenines/cowlib/blob/d0cd6dcb338425a24f85f37ab1ba6d9aeaca89bb/src/cow_hpack.erl#L563) by Loïc Hoguin (@essen) was a great help while writing this library.
 
 ## feature wishes / ideas / contribute
+
 Nice to have:
+
 - transcoding for intermediaries (`never indexed`)
 - handle small tables in a performant way (keep track of headers)
 
-*please write test <3*
+*please write test* <3
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ The HPack library has a simple interface. You will need two functions:
 
 ```elixir
 {:ok, table, hbf} =
-  1_000
-  |> HPack.Table.new()
+  HPack.Table.new(1_000)
   |> HPack.encode([{":method", "GET"}])
 # => {:ok, ..., << 0b10000010 >>}
 ```

--- a/lib/hpack.ex
+++ b/lib/hpack.ex
@@ -20,8 +20,7 @@ defmodule HPack do
 
   ### Examples
 
-      iex> ctx = HPack.Table.new(1_000)
-      iex> {:ok, table, << 0b10000010 >>} = HPack.encode(ctx, [{":method", "GET"}])
+      iex> {:ok, table, << 0b10000010 >>} = 1_000 |> HPack.Table.new() |> HPack.encode([{":method", "GET"}])
       {:ok, %HPack.Table{size: 1000, table: []}, <<130>>}
   """
   @spec encode(Table.t(), headers()) ::
@@ -84,8 +83,7 @@ defmodule HPack do
 
   ### Examples
 
-      iex> ctx = HPack.Table.new(1_000)
-      iex> {:ok, table, [{":method", "GET"}]} = HPack.decode(ctx, << 0x82 >>)
+      iex> {:ok, table, [{":method", "GET"}]} = 1_000 |> HPack.Table.new() |> HPack.decode(<< 0x82 >>)
       {:ok, %HPack.Table{size: 1000, table: []}, [{":method", "GET"}]}
   """
   @spec decode(Table.t(), header_block_fragment, Table.size() | nil) ::

--- a/lib/hpack.ex
+++ b/lib/hpack.ex
@@ -20,7 +20,7 @@ defmodule HPack do
 
   ### Examples
 
-      iex> {:ok, table, << 0b10000010 >>} = 1_000 |> HPack.Table.new() |> HPack.encode([{":method", "GET"}])
+      iex> {:ok, table, << 0b10000010 >>} = HPack.Table.new(1_000) |> HPack.encode([{":method", "GET"}])
       {:ok, %HPack.Table{size: 1000, table: []}, <<130>>}
   """
   @spec encode(Table.t(), headers()) ::
@@ -83,7 +83,7 @@ defmodule HPack do
 
   ### Examples
 
-      iex> {:ok, table, [{":method", "GET"}]} = 1_000 |> HPack.Table.new() |> HPack.decode(<< 0x82 >>)
+      iex> {:ok, table, [{":method", "GET"}]} = HPack.Table.new(1_000) |> HPack.decode(<< 0x82 >>)
       {:ok, %HPack.Table{size: 1000, table: []}, [{":method", "GET"}]}
   """
   @spec decode(Table.t(), header_block_fragment, Table.size() | nil) ::

--- a/lib/hpack/table.ex
+++ b/lib/hpack/table.ex
@@ -113,7 +113,7 @@ defmodule HPack.Table do
   def resize(size, table, max_size \\ nil)
 
   def resize(size, table, max_size)
-  when not is_integer(max_size) or size < max_size do
+  when not is_integer(max_size) or size <= max_size do
     Agent.update(table, fn state ->
       %{state | size: size}
     end)

--- a/test/hpack/huffman_test.exs
+++ b/test/hpack/huffman_test.exs
@@ -11,18 +11,8 @@ defmodule HuffmanTest do
 
   test "decode a sentence" do
     hello_world = <<
-      0x27::6,
-      0x5::5,
-      0x28::6,
-      0x28::6,
-      0x7::5,
-      0x14::6,
-      0x78::7,
-      0x7::5,
-      0x2C::6,
-      0x28::6,
-      0x24::6,
-      0x3F8::10
+      0x27::6, 0x5::5, 0x28::6, 0x28::6, 0x7::5, 0x14::6,
+      0x78::7, 0x7::5, 0x2C::6, 0x28::6, 0x24::6, 0x3F8::10
     >>
 
     assert {:ok, "hello world!"} == Huffman.decode(hello_world)
@@ -30,12 +20,7 @@ defmodule HuffmanTest do
 
   test "decode with padding" do
     hello = <<
-      0x27::6,
-      0x5::5,
-      0x28::6,
-      0x28::6,
-      0x7::5,
-      0b1111::4
+      0x27::6, 0x5::5, 0x28::6, 0x28::6, 0x7::5, 0b1111::4
     >>
 
     assert {:ok, "hello"} == Huffman.decode(hello)
@@ -50,22 +35,9 @@ defmodule HuffmanTest do
   end
 
   test "encode a sentence" do
-    assert Huffman.encode("hello world!") ==
-             {:ok,
-              <<
-                0x27::6,
-                0x5::5,
-                0x28::6,
-                0x28::6,
-                0x7::5,
-                0x14::6,
-                0x78::7,
-                0x7::5,
-                0x2C::6,
-                0x28::6,
-                0x24::6,
-                0x3F8::10,
-                0b111111::6
-              >>}
+    assert Huffman.encode("hello world!") == {:ok, <<
+      0x27::6, 0x5::5, 0x28::6, 0x28::6, 0x7::5, 0x14::6,
+      0x78::7, 0x7::5, 0x2C::6, 0x28::6, 0x24::6, 0x3F8::10, 0b111111::6
+    >>}
   end
 end

--- a/test/hpack/table_test.exs
+++ b/test/hpack/table_test.exs
@@ -11,68 +11,68 @@ defmodule HPack.TableTest do
   end
 
   test "resize table to smaller than max size", %{table: table} do
-    assert {:ok, _table} = Table.resize(table, @max_size / 2, @max_size)
+    assert {:ok, _table} = Table.resize(@max_size / 2, table, @max_size)
   end
 
   test "resize table to equal to max size", %{table: table} do
-    assert {:ok, _table} = Table.resize(table, @max_size, @max_size)
+    assert {:ok, _table} = Table.resize(@max_size, table, @max_size)
   end
 
   test "resize table to larger than max size fails", %{table: table} do
-    assert {:error, :decode_error} = Table.resize(table, @max_size + 1, @max_size)
+    assert {:error, :decode_error} = Table.resize(@max_size + 1, table, @max_size)
   end
 
   test "lookp up from static table", %{table: table} do
-    assert {:ok, {":method", "GET"}} = Table.lookup(table, 2)
+    assert {:ok, {":method", "GET"}} = Table.lookup(2, table)
   end
 
   test "adding to dynamic table", %{table: table} do
     header = {"some-header", "some-value"}
-    assert {:ok, table} = Table.add(table, header)
-    assert {:ok, header} == Table.lookup(table, 62)
+    assert {:ok, table} = Table.add(header, table)
+    assert {:ok, header} == Table.lookup(62, table)
   end
 
   test "adds to dynamic table at the beginning", %{table: table} do
     second_header = {"some-header-2", "some-value-2"}
-    assert {:ok, table} = Table.add(table, {"some-header", "some-value"})
-    assert {:ok, table} = Table.add(table, second_header)
-    assert {:ok, second_header} == Table.lookup(table, 62)
+    assert {:ok, table} = Table.add({"some-header", "some-value"}, table)
+    assert {:ok, table} = Table.add(second_header, table)
+    assert {:ok, second_header} == Table.lookup(62, table)
   end
 
   test "evict entries on table size change", %{table: table} do
     header = {"some-header", "some-value"}
-    assert {:ok, table} = Table.add(table, header)
+    assert {:ok, table} = Table.add(header, table)
     # evict all entries in dynamic table
-    assert {:ok, table} = Table.resize(table, 0)
-    assert {:error, :not_found} == Table.lookup(table, 62)
+    assert {:ok, table} = Table.resize(0, table)
+    assert {:error, :not_found} == Table.lookup(62, table)
   end
 
   test "evict oldest entries when size > table size", %{table: table} do
-    assert {:ok, table} = Table.resize(table, 60)
+    assert {:ok, table} = Table.resize(60, table)
 
     third_header = {"some-header-3", "some-value-3"}
-    assert {:ok, table} = Table.add(table, {"some-header", "some-value"})
-    assert {:ok, table} = Table.add(table, {"some-header-2", "some-value-2"})
-    assert {:ok, table} = Table.add(table, third_header)
+    assert {:ok, table} = Table.add({"some-header", "some-value"}, table)
+    assert {:ok, table} = Table.add({"some-header-2", "some-value-2"}, table)
+    assert {:ok, table} = Table.add(third_header, table)
 
-    assert {:ok, third_header} == Table.lookup(table, 62)
-    assert {:error, :not_found} == Table.lookup(table, 63)
+    assert {:ok, third_header} == Table.lookup(62, table)
+    assert {:error, :not_found} == Table.lookup(63, table)
   end
 
   test "find a key with corresponding value from static table", %{table: table} do
-    assert Table.find(table, ":method", "GET") == {:fullindex, 2}
+    assert Table.find(":method", "GET", table) == {:fullindex, 2}
   end
 
   test "find a key without corresponding value from static table", %{table: table} do
-    assert Table.find(table, "etag", "1e2345678") == {:keyindex, 34}
+    assert Table.find("etag", "1e2345678", table) == {:keyindex, 34}
   end
 
   test "return :none when key not found in table", %{table: table} do
-    assert Table.find(table, "x-something", "some-value") == {:error, :not_found}
+    assert Table.find("x-something", "some-value", table) == {:error, :not_found}
   end
 
   test "find a key with corresponding value from dynamic table", %{table: table} do
-    assert {:ok, table} = Table.add(table, {"x-something", "some-value"})
-    assert Table.find(table, "x-something", "some-value") == {:fullindex, 62}
+    assert {:ok, table} = Table.add({"x-something", "some-value"}, table)
+    assert Table.find("x-something", "some-value", table) == {:fullindex, 62}
   end
 end

--- a/test/hpack_test.exs
+++ b/test/hpack_test.exs
@@ -10,21 +10,21 @@ defmodule HPackTest do
   end
 
   test "decode from static table", %{table: table} do
-    assert {:ok, _table, [{":method", "GET"}]} = HPack.decode(table, <<0x82>>)
+    assert {:ok, _table, [{":method", "GET"}]} = HPack.decode(<<0x82>>, table)
   end
 
   test "decode big number (Index5+)", %{table: table} do
     # make it big enough
-    assert {:ok, table} = Table.resize(table, 1_000_000_000)
+    assert {:ok, table} = Table.resize(1_000_000_000, table)
 
     {:ok, table} =
       Enum.reduce(1..1337, {:ok, table}, fn i, {:ok, table} ->
-        Table.add(table, {"h-#{i}", "v-#{i}"})
+        Table.add({"h-#{i}", "v-#{i}"}, table)
       end)
 
     # Maximum Dynamic Table Size Change header to 1337
     hbf = <<0b00111111, 0b10011010, 0b00001010>>
-    assert {:ok, table, headers} = HPack.decode(table, hbf)
+    assert {:ok, table, headers} = HPack.decode(hbf, table)
 
     assert Table.size(table) <= 1337
     assert headers == []
@@ -34,12 +34,12 @@ defmodule HPackTest do
     super_long_value =
       "very long long value Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam,"
 
-    assert {:ok, _table, hbf} = HPack.encode(table, [{"short-key", super_long_value}])
+    assert {:ok, _table, hbf} = HPack.encode([{"short-key", super_long_value}], table)
 
     decode_table = Table.new(1_000)
 
     assert {:ok, _decode_table, [{"short-key", super_long_value}]} =
-             HPack.decode(decode_table, hbf)
+             HPack.decode(hbf, decode_table)
   end
 
   @doc """
@@ -84,6 +84,6 @@ defmodule HPackTest do
         170, 98, 163, 132, 143, 210, 74, 143>>
 
     table = Table.new(4_096)
-    assert {:ok, _table, [_head | _tail]} = HPack.decode(table, data)
+    assert {:ok, _table, [_head | _tail]} = HPack.decode(data, table)
   end
 end

--- a/test/rfc-spec/decode_test.exs
+++ b/test/rfc-spec/decode_test.exs
@@ -16,7 +16,7 @@ defmodule HPack.RFCSpec.DecodeTest do
       746f 6d2d 6865 6164 6572                | tom-header
     )
 
-    assert {:ok, table, [decoded_header | _]} = HPack.decode(table, hbf)
+    assert {:ok, table, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {"custom-key", "custom-header"}
     assert Table.size(table) == 55
   end
@@ -26,7 +26,7 @@ defmodule HPack.RFCSpec.DecodeTest do
   test "Literal Header Field without Indexing", %{table: table} do
     hbf = ~b(040c 2f73 616d 706c 652f 7061 7468      | ../sample/path)
 
-    assert {:ok, table, [decoded_header | _]} = HPack.decode(table, hbf)
+    assert {:ok, table, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {":path", "/sample/path"}
     assert Table.size(table) == 0
   end
@@ -39,7 +39,7 @@ defmodule HPack.RFCSpec.DecodeTest do
       74                                      | t
     )
 
-    assert {:ok, table, [decoded_header | _]} = HPack.decode(table, hbf)
+    assert {:ok, table, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {"password", "secret"}
     assert Table.size(table) == 0
   end
@@ -49,7 +49,7 @@ defmodule HPack.RFCSpec.DecodeTest do
   test "Indexed Header Field", %{table: table} do
     hbf = ~b(82 | .)
 
-    assert {:ok, table, [decoded_header | _]} = HPack.decode(table, hbf)
+    assert {:ok, table, [decoded_header | _]} = HPack.decode(hbf, table)
     assert decoded_header == {":method", "GET"}
     assert Table.size(table) == 0
   end
@@ -69,7 +69,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {":scheme", "http"},
               {":path", "/"},
               {":authority", "www.example.com"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 57
 
@@ -85,7 +85,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {":path", "/"},
               {":authority", "www.example.com"},
               {"cache-control", "no-cache"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 110
 
@@ -102,7 +102,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {":path", "/index.html"},
               {":authority", "www.example.com"},
               {"custom-key", "custom-value"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 164
   end
@@ -122,7 +122,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {":scheme", "http"},
               {":path", "/"},
               {":authority", "www.example.com"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 57
 
@@ -138,7 +138,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {":path", "/"},
               {":authority", "www.example.com"},
               {"cache-control", "no-cache"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 110
 
@@ -155,7 +155,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {":path", "/index.html"},
               {":authority", "www.example.com"},
               {"custom-key", "custom-value"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 164
   end
@@ -163,7 +163,7 @@ defmodule HPack.RFCSpec.DecodeTest do
   # C.5 Response Examples without Huffman Coding
   @tag :rfc
   test "Response Examples without Huffman Coding", %{table: table} do
-    assert {:ok, table} = Table.resize(table, 256)
+    assert {:ok, table} = Table.resize(256, table)
 
     # C.5.1 First Response
     hbf = ~b(
@@ -180,7 +180,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {"cache-control", "private"},
               {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
               {"location", "https://www.example.com"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 222
 
@@ -195,7 +195,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {"cache-control", "private"},
               {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
               {"location", "https://www.example.com"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 222
 
@@ -218,7 +218,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {"location", "https://www.example.com"},
               {"content-encoding", "gzip"},
               {"set-cookie", "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 215
   end
@@ -226,7 +226,7 @@ defmodule HPack.RFCSpec.DecodeTest do
   # C.6 Response Examples with Huffman Coding
   @tag :rfc
   test "Response Examples with Huffman Coding", %{table: table} do
-    assert {:ok, table} = Table.resize(table, 256)
+    assert {:ok, table} = Table.resize(256, table)
 
     # C.6.1 First Response
     hbf = ~b/
@@ -242,7 +242,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {"cache-control", "private"},
               {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
               {"location", "https://www.example.com"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 222
 
@@ -257,7 +257,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {"cache-control", "private"},
               {"date", "Mon, 21 Oct 2013 20:13:21 GMT"},
               {"location", "https://www.example.com"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 222
 
@@ -278,7 +278,7 @@ defmodule HPack.RFCSpec.DecodeTest do
               {"location", "https://www.example.com"},
               {"content-encoding", "gzip"},
               {"set-cookie", "foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1"}
-            ]} = HPack.decode(table, hbf)
+            ]} = HPack.decode(hbf, table)
 
     assert Table.size(table) == 215
   end

--- a/test/rfc-spec/encode_test.exs
+++ b/test/rfc-spec/encode_test.exs
@@ -13,7 +13,7 @@ defmodule HPack.RFCSpec.EncodeTest do
   test "Indexed Header Field", %{table: table} do
     headers = [{":method", "GET"}]
     hbf = ~b(82 | .)
-    assert {:ok, table, ^hbf} = HPack.encode(table, headers)
+    assert {:ok, table, ^hbf} = HPack.encode(headers, table)
   end
 
   # C.4 Request Examples with Huffman Coding
@@ -32,7 +32,7 @@ defmodule HPack.RFCSpec.EncodeTest do
       ff                                      | .
     )
 
-    assert {:ok, table, ^hbf} = HPack.encode(table, headers)
+    assert {:ok, table, ^hbf} = HPack.encode(headers, table)
 
     # C.4.2 Second Request
     headers = [
@@ -47,7 +47,7 @@ defmodule HPack.RFCSpec.EncodeTest do
       8286 84be 5886 a8eb 1064 9cbf           | ....X....d..
     )
 
-    assert {:ok, table, ^hbf} = HPack.encode(table, headers)
+    assert {:ok, table, ^hbf} = HPack.encode(headers, table)
 
     # C.4.3 Third Request
     headers = [
@@ -63,13 +63,13 @@ defmodule HPack.RFCSpec.EncodeTest do
       a849 e95b b8e8 b4bf                     | .I.[....
     )
 
-    assert {:ok, table, ^hbf} = HPack.encode(table, headers)
+    assert {:ok, table, ^hbf} = HPack.encode(headers, table)
   end
 
   # C.6 Response Examples with Huffman Coding
   @tag :rfc
   test "Request Examples with Huffman Coding (256 bytes table)", %{table: table} do
-    Table.resize(table, 256)
+    Table.resize(256, table)
 
     # C.6.1 First Response
     headers = [
@@ -86,7 +86,7 @@ defmodule HPack.RFCSpec.EncodeTest do
       e9ae 82ae 43d3                          | ....C.
     /
 
-    assert {:ok, table, ^hbf} = HPack.encode(table, headers)
+    assert {:ok, table, ^hbf} = HPack.encode(headers, table)
 
     # C.6.2 Second Response
     headers = [
@@ -100,7 +100,7 @@ defmodule HPack.RFCSpec.EncodeTest do
       4883 640e ffc1 c0bf                     | H.d.....
     )
 
-    assert {:ok, table, ^hbf} = HPack.encode(table, headers)
+    assert {:ok, table, ^hbf} = HPack.encode(headers, table)
 
     # C.6.3 Third Response
     headers = [
@@ -120,6 +120,6 @@ defmodule HPack.RFCSpec.EncodeTest do
       9587 3160 65c0 03ed 4ee5 b106 3d50 07   | ..1`e...N...=P.
     /
 
-    assert {:ok, table, ^hbf} = HPack.encode(table, headers)
+    assert {:ok, table, ^hbf} = HPack.encode(headers, table)
   end
 end


### PR DESCRIPTION
This removes the need to run the compression/decompression context in a separate process.

I'm using this for my HTTP/2 implementation, which is a processless library. I think this allows for both use-cases since wrapping this library in a process if needed is quite easy.

It also cleans up the APIs to use the context as first argument which I think makes it more consistent and intuitive.

I have a few ides to further optimize the static table handling, but I'd like to get this in first.

I think I'm already aiming for 3.0.0 here 😄 