### PR TITLE
Fix table resizing

### DIFF
--- a/lib/hpack/table.ex
+++ b/lib/hpack/table.ex
@@ -113,7 +113,7 @@ defmodule HPack.Table do
   def resize(size, table, max_size \\ nil)
 
   def resize(size, table, max_size)
-  when not is_integer(max_size) or size < max_size do
+  when not is_integer(max_size) or size <= max_size do
     Agent.update(table, fn state ->
       %{state | size: size}
     end)

--- a/test/hpack/table_test.exs
+++ b/test/hpack/table_test.exs
@@ -4,9 +4,23 @@ defmodule HPack.TableTest do
   alias HPack.Table
   doctest Table
 
+  @max_size 1_000
+
   setup do
-    {:ok, table} = Table.start_link(1_000)
+    {:ok, table} = Table.start_link(@max_size)
     {:ok, table: table}
+  end
+
+  test "resize table to smaller than max size", %{table: table} do
+    assert :ok = Table.resize(500, table, @max_size)
+  end
+
+  test "resize table to equal to max size", %{table: table} do
+    assert :ok = Table.resize(1_000, table, @max_size)
+  end
+
+  test "resize table to larger than max size fails", %{table: table} do
+    assert {:error, :decode_error} = Table.resize(@max_size + 1, table, @max_size)
   end
 
   test "lookp up from static table", %{table: table} do

--- a/test/hpack/table_test.exs
+++ b/test/hpack/table_test.exs
@@ -16,7 +16,7 @@ defmodule HPack.TableTest do
   end
 
   test "resize table to equal to max size", %{table: table} do
-    assert :ok = Table.resize(1_000, table, @max_size)
+    assert :ok = Table.resize(@max_size, table, @max_size)
   end
 
   test "resize table to larger than max size fails", %{table: table} do

--- a/test/hpack/table_test.exs
+++ b/test/hpack/table_test.exs
@@ -12,7 +12,7 @@ defmodule HPack.TableTest do
   end
 
   test "resize table to smaller than max size", %{table: table} do
-    assert :ok = Table.resize(500, table, @max_size)
+    assert :ok = Table.resize(@max_size / 2, table, @max_size)
   end
 
   test "resize table to equal to max size", %{table: table} do


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc7541#section-6.3 table size updates MUST be lower or equal to the externally determined maximum table size.
Currently, only strictly lower values are accepted, equal values result in an error.